### PR TITLE
Let them use it both ways

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-export default {
-	getLayerContext: function (el) {
-		return el.closest('.o-layers__context') || document.body;
-	}
+export let getLayerContext = function (el) {
+	return el.closest('.o-layers__context') || document.body;
 };
+
+export default { getLayerContext };


### PR DESCRIPTION
```
const {getLayerContext} = require('o-layers');
```
and
```
import {getLayerContext} from 'o-layers';
```
and
```
import oLayers from 'o-layers';
const {getLayerContext} = oLayers;
```