### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/layers.test.js
+++ b/test/layers.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
+/* global proclaim */
 
 import oLayers from './../main.js';
-import proclaim from 'proclaim';
 
 describe('o-layers', function() {
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.